### PR TITLE
CC-6499 Adds a development mode for copying development dependencies.

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -7,6 +7,8 @@ var path = require('path');
 var root = process.cwd();
 var pkg = require(path.join(root, 'package.json'));
 
+var isProduction = process.env.npm_config_production === 'true' || process.env.NODE_ENV === 'production';
+
 function logDone(items){
     items.forEach(function(item){
         console.log(item.from + ' => ' + item.to);
@@ -18,4 +20,10 @@ function logError(error){
     process.exit(1);
 }
 
-vendorCopy(root, pkg.vendorCopy || []).then(logDone, logError);
+var toCopy = pkg.vendorCopy || [];
+
+if (!isProduction) {
+    toCopy = toCopy.concat(pkg.devVendorCopy || []);
+}
+
+vendorCopy(root, toCopy).then(logDone, logError);

--- a/tests/cli.js
+++ b/tests/cli.js
@@ -13,79 +13,270 @@ describe('cli', function(){
     var errorStub = sandbox.stub();
     var exitStub = sandbox.stub();
     var packagePath = path.join(__dirname, '..', 'package.json');
+    var fakeProcess;
+    var requires;
     var vendorCopyDeferred;
 
     beforeEach(function(){
         vendorCopyDeferred = new Deferred();
         vendorCopyStub.returns(vendorCopyDeferred.promise);
 
-        var requires = {
+        requires = {
             '.': vendorCopyStub
         };
 
         requires[packagePath] = {
-            vendorCopy: 'vendor-copy-config'
+            vendorCopy: ['vendor-copy-config'],
+            devVendorCopy: ['dev-vendor-copy-config']
         };
 
-        SandboxedModule.require('../cli', {
-            requires: requires,
-            globals: {
-                console: {
-                    log: infoStub,
-                    error: errorStub
-                },
-                process: {
-                    exit: exitStub,
-                    cwd: process.cwd
-                }
-            }
-        });
+        fakeProcess = {
+            exit: exitStub,
+            cwd: process.cwd
+        };
     });
 
     afterEach(function(){
         sandbox.reset();
     });
 
-    it('calls the library with the root and the "vendorCopy" field of the package.json file', function(){
-        assert.deepEqual(vendorCopyStub.args, [[path.join(__dirname, '..'), 'vendor-copy-config']]);
-    });
-
-    describe('when the library call resolves', function(){
+    describe('npm development mode', function(){
         beforeEach(function(){
-            vendorCopyDeferred.resolve([
-                {
-                    from: 'from1',
-                    to: 'to1'
-                },
-                {
-                    from: 'from2',
-                    to: 'to2'
+            fakeProcess.env = {npm_config_production: 'false'};
+
+            SandboxedModule.require('../cli', {
+                requires: requires,
+                globals: {
+                    console: {
+                        log: infoStub,
+                        error: errorStub
+                    },
+                    process: fakeProcess
                 }
-            ]);
-
-            return vendorCopyDeferred.promise;
+            });
         });
 
-        it('logs each copy', function(){
-            assert.deepEqual(infoStub.args, [['from1 => to1'], ['from2 => to2']]);
+        it('calls the library with the root and the "vendorCopy" and "devVendorCopy" fields of the package.json file', function(){
+            assert.deepEqual(vendorCopyStub.args, [[path.join(__dirname, '..'), ['vendor-copy-config', 'dev-vendor-copy-config']]]);
         });
-    });
 
-    describe('when the library call rejects', function(){
-        beforeEach(function(){
-            vendorCopyDeferred.reject({
-                stack: 'fake error stack'
+        describe('when the library call resolves', function(){
+            beforeEach(function(){
+                vendorCopyDeferred.resolve([
+                    {
+                        from: 'from1',
+                        to: 'to1'
+                    },
+                    {
+                        from: 'from2',
+                        to: 'to2'
+                    }
+                ]);
+
+                return vendorCopyDeferred.promise;
             });
 
-            return vendorCopyDeferred.promise.catch(function(){});
+            it('logs each copy', function(){
+                assert.deepEqual(infoStub.args, [['from1 => to1'], ['from2 => to2']]);
+            });
         });
 
-        it('logs the error', function(){
-            assert.deepEqual(errorStub.args, [['Failed to install vendor modules:', 'fake error stack']]);
+        describe('when the library call rejects', function(){
+            beforeEach(function(){
+                vendorCopyDeferred.reject({
+                    stack: 'fake error stack'
+                });
+
+                return vendorCopyDeferred.promise.catch(function(){});
+            });
+
+            it('logs the error', function(){
+                assert.deepEqual(errorStub.args, [['Failed to install vendor modules:', 'fake error stack']]);
+            });
+
+            it('exits the process with status 1', function(){
+                assert.deepStrictEqual(exitStub.args, [[1]]);
+            });
+        });
+    });
+
+    describe('NODE_ENV development mode', function(){
+        beforeEach(function(){
+            fakeProcess.env = {NODE_ENV: 'development'};
+
+            SandboxedModule.require('../cli', {
+                requires: requires,
+                globals: {
+                    console: {
+                        log: infoStub,
+                        error: errorStub
+                    },
+                    process: fakeProcess
+                }
+            });
         });
 
-        it('exits the process with status 1', function(){
-            assert.deepStrictEqual(exitStub.args, [[1]]);
+        it('calls the library with the root and the "vendorCopy" field of the package.json file', function(){
+            assert.deepEqual(vendorCopyStub.args, [[path.join(__dirname, '..'), ['vendor-copy-config', 'dev-vendor-copy-config']]]);
+        });
+
+        describe('when the library call resolves', function(){
+            beforeEach(function(){
+                vendorCopyDeferred.resolve([
+                    {
+                        from: 'from1',
+                        to: 'to1'
+                    },
+                    {
+                        from: 'from2',
+                        to: 'to2'
+                    }
+                ]);
+
+                return vendorCopyDeferred.promise;
+            });
+
+            it('logs each copy', function(){
+                assert.deepEqual(infoStub.args, [['from1 => to1'], ['from2 => to2']]);
+            });
+        });
+
+        describe('when the library call rejects', function(){
+            beforeEach(function(){
+                vendorCopyDeferred.reject({
+                    stack: 'fake error stack'
+                });
+
+                return vendorCopyDeferred.promise.catch(function(){});
+            });
+
+            it('logs the error', function(){
+                assert.deepEqual(errorStub.args, [['Failed to install vendor modules:', 'fake error stack']]);
+            });
+
+            it('exits the process with status 1', function(){
+                assert.deepStrictEqual(exitStub.args, [[1]]);
+            });
+        });
+    });
+
+    describe('npm production mode', function(){
+        beforeEach(function(){
+            fakeProcess.env = {npm_config_production: 'true'};
+
+            SandboxedModule.require('../cli', {
+                requires: requires,
+                globals: {
+                    console: {
+                        log: infoStub,
+                        error: errorStub
+                    },
+                    process: fakeProcess
+                }
+            });
+        });
+
+        it('calls the library with the root and the "vendorCopy" field of the package.json file', function(){
+            assert.deepEqual(vendorCopyStub.args, [[path.join(__dirname, '..'), ['vendor-copy-config']]]);
+        });
+
+        describe('when the library call resolves', function(){
+            beforeEach(function(){
+                vendorCopyDeferred.resolve([
+                    {
+                        from: 'from1',
+                        to: 'to1'
+                    },
+                    {
+                        from: 'from2',
+                        to: 'to2'
+                    }
+                ]);
+
+                return vendorCopyDeferred.promise;
+            });
+
+            it('logs each copy', function(){
+                assert.deepEqual(infoStub.args, [['from1 => to1'], ['from2 => to2']]);
+            });
+        });
+
+        describe('when the library call rejects', function(){
+            beforeEach(function(){
+                vendorCopyDeferred.reject({
+                    stack: 'fake error stack'
+                });
+
+                return vendorCopyDeferred.promise.catch(function(){});
+            });
+
+            it('logs the error', function(){
+                assert.deepEqual(errorStub.args, [['Failed to install vendor modules:', 'fake error stack']]);
+            });
+
+            it('exits the process with status 1', function(){
+                assert.deepStrictEqual(exitStub.args, [[1]]);
+            });
+        });
+    });
+
+    describe('NODE_ENV production mode', function(){
+        beforeEach(function(){
+            fakeProcess.env = {NODE_ENV: 'production'};
+
+            SandboxedModule.require('../cli', {
+                requires: requires,
+                globals: {
+                    console: {
+                        log: infoStub,
+                        error: errorStub
+                    },
+                    process: fakeProcess
+                }
+            });
+        });
+
+        it('calls the library with the root and the "vendorCopy" field of the package.json file', function(){
+            assert.deepEqual(vendorCopyStub.args, [[path.join(__dirname, '..'), ['vendor-copy-config']]]);
+        });
+
+        describe('when the library call resolves', function(){
+            beforeEach(function(){
+                vendorCopyDeferred.resolve([
+                    {
+                        from: 'from1',
+                        to: 'to1'
+                    },
+                    {
+                        from: 'from2',
+                        to: 'to2'
+                    }
+                ]);
+
+                return vendorCopyDeferred.promise;
+            });
+
+            it('logs each copy', function(){
+                assert.deepEqual(infoStub.args, [['from1 => to1'], ['from2 => to2']]);
+            });
+        });
+
+        describe('when the library call rejects', function(){
+            beforeEach(function(){
+                vendorCopyDeferred.reject({
+                    stack: 'fake error stack'
+                });
+
+                return vendorCopyDeferred.promise.catch(function(){});
+            });
+
+            it('logs the error', function(){
+                assert.deepEqual(errorStub.args, [['Failed to install vendor modules:', 'fake error stack']]);
+            });
+
+            it('exits the process with status 1', function(){
+                assert.deepStrictEqual(exitStub.args, [[1]]);
+            });
         });
     });
 });


### PR DESCRIPTION
Works both in standalone (using `NODE_ENV`) and as an npm run script (using the npm provided `npm_config_production` variable).

@vizia/vizia-dev Ready for review.
