### PR TITLE
Only publish necessary files.

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "bin": {
     "vendor-copy": "./cli.js"
   },
+  "files": [
+    "index.js",
+    "cli.js"
+  ],
   "dependencies": {
     "mkdirp": "0.5.1",
     "ncp": "2.0.0"


### PR DESCRIPTION
Since this is a public tool, it's nice to get the published size down as much as possible.