### PR TITLE
Fix copying symlinks

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -16,7 +16,7 @@ function logDone(items) {
 }
 
 function logError(error) {
-    console.error('Failed to install vendor modules:', error.stack); // eslint-disable-line no-console
+    console.error('Failed to install vendor modules:', error); // eslint-disable-line no-console
     process.exit(1);
 }
 

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ function ensureDir(fromTo) {
 
 function copyFile(fromTo) {
     return new Promise(function (resolve, reject) {
-        ncp(fromTo.from, fromTo.to, function (err) {
+        ncp(fromTo.from, fromTo.to, {dereference: true}, function (err) {
             if (err) {
                 reject(err);
             } else {

--- a/tests/cli.js
+++ b/tests/cli.js
@@ -91,7 +91,7 @@ describe('cli', function () {
             });
 
             it('logs the error', function () {
-                assert.deepEqual(errorStub.args, [['Failed to install vendor modules:', 'fake error stack']]);
+                assert.deepEqual(errorStub.args, [['Failed to install vendor modules:', {stack: 'fake error stack'}]]);
             });
 
             it('exits the process with status 1', function () {
@@ -151,7 +151,7 @@ describe('cli', function () {
             });
 
             it('logs the error', function () {
-                assert.deepEqual(errorStub.args, [['Failed to install vendor modules:', 'fake error stack']]);
+                assert.deepEqual(errorStub.args, [['Failed to install vendor modules:', {stack: 'fake error stack'}]]);
             });
 
             it('exits the process with status 1', function () {
@@ -211,7 +211,7 @@ describe('cli', function () {
             });
 
             it('logs the error', function () {
-                assert.deepEqual(errorStub.args, [['Failed to install vendor modules:', 'fake error stack']]);
+                assert.deepEqual(errorStub.args, [['Failed to install vendor modules:', {stack: 'fake error stack'}]]);
             });
 
             it('exits the process with status 1', function () {
@@ -271,7 +271,7 @@ describe('cli', function () {
             });
 
             it('logs the error', function () {
-                assert.deepEqual(errorStub.args, [['Failed to install vendor modules:', 'fake error stack']]);
+                assert.deepEqual(errorStub.args, [['Failed to install vendor modules:', {stack: 'fake error stack'}]]);
             });
 
             it('exits the process with status 1', function () {


### PR DESCRIPTION
Pass the `dereference` option to `ncp` so that symlinks don't fail to copy.  This is useful when using `npm link`

I've also fixed how errors are logged - in this instance the error didn't have a stack or message property so all that was being logged was `Failed to install vendor modules: undefined` which is super-helpful.  Now the app just logs the full Error object